### PR TITLE
Added support for DWAA/B EXR compression method

### DIFF
--- a/openexr/IlmImf/ImfCRgbaFile.h
+++ b/openexr/IlmImf/ImfCRgbaFile.h
@@ -113,6 +113,8 @@ typedef struct ImfRgba ImfRgba;
 #define IMF_PXR24_COMPRESSION	5
 #define IMF_B44_COMPRESSION	6
 #define IMF_B44A_COMPRESSION	7
+#define IMF_DWAA_COMPRESSION	8
+#define IMF_DWAB_COMPRESSION	9
 
 
 /*


### PR DESCRIPTION
**Problem**
- It was impossible to write an EXR with the DWAA/DWAB Compression methods even though everything is present in the Exr library

**Solution**
- Add the missing defines
